### PR TITLE
Fixed the handling of startPolling/stopPolling and some other minor issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ Temporary Items
 .apdisk
 
 #################
+## Jetbrains IDEs
+#################
+.idea
+
+#################
 ## Eclipse
 #################
 

--- a/drivers/energylink/driver.js
+++ b/drivers/energylink/driver.js
@@ -1,4 +1,4 @@
-var devices = [];
+var devices = {};
 var homewizard = require('./../../includes/homewizard.js');
 var refreshIntervalId = 0;
 
@@ -68,9 +68,11 @@ module.exports.init = function(devices_data, callback) {
 };
 
 module.exports.deleted = function( device_data ) {
-    clearInterval(refreshIntervalId);
-    console.log("--Stopped Polling Energy Link--");  
-    devices = [];
+    delete devices[device_data.id];
+    if (Object.keys(devices).length === 0) {
+        clearInterval(refreshIntervalId);
+        console.log("--Stopped Polling Energy Link--");
+    }
     Homey.log('deleted: ' + JSON.stringify(device_data));
 };
 
@@ -145,12 +147,15 @@ module.exports.capabilities = {
 
 // Start polling
 function startPolling() {
-  refreshIntervalId = setInterval(function () {
-    console.log("--Start Energylink Polling-- ");
-    Object.keys(devices).forEach(function (device_id) {
-      getStatus(device_id);
-    });
-  }, 1000 * 10);
+    if(refreshIntervalId){
+        clearInterval(refreshIntervalId);
+    }
+    refreshIntervalId = setInterval(function () {
+        console.log("--Start Energylink Polling-- ");
+        Object.keys(devices).forEach(function (device_id) {
+            getStatus(device_id);
+        });
+    }, 1000 * 10);
 }
 
 function getStatus(device_id) {
@@ -243,6 +248,11 @@ function getStatus(device_id) {
     } else {
         Homey.log('Removed Energylink '+ device_id +' (wrong settings)');
         module.exports.setUnavailable({id: device_id}, "No Energylink found" );
-        clearInterval(refreshIntervalId);
+        // Only clear interval when the unavailable device is the only device on this driver
+        // This will prevent stopping the polling when a user has 1 device with old settings and 1 with new
+        // In the event that a user has multiple devices with old settings this function will get called every 10 seconds but that should not be a problem
+        if(Object.keys(devices).length === 1) {
+            clearInterval(refreshIntervalId);
+        }
     }
 }

--- a/drivers/heatlink/driver.js
+++ b/drivers/heatlink/driver.js
@@ -1,4 +1,4 @@
-var devices = [];
+var devices = {};
 var homewizard = require('./../../includes/homewizard.js');
 var refreshIntervalId = 0;
 
@@ -69,9 +69,11 @@ module.exports.init = function(devices_data, callback) {
 };
 
 module.exports.deleted = function( device_data ) {
-    clearInterval(refreshIntervalId);
-    Homey.log("--Stopped Polling--");  
-    devices = [];
+    delete devices[device_data.id];
+    if (Object.keys(devices).length === 0) {
+        clearInterval(refreshIntervalId);
+        Homey.log("--Stopped Polling--");
+    }
     Homey.log('deleted: ' + JSON.stringify(device_data));
 };
 
@@ -83,7 +85,7 @@ module.exports.capabilities = {
       if (device instanceof Error) return callback(device);
       console.log("measure_temperature");
       getStatus(device.id);
-      newvalue = devices[device.id].temperature;
+      var newvalue = devices[device.id].temperature;
       // Callback ambient temperature
       callback(null, newvalue);
     }
@@ -95,6 +97,7 @@ module.exports.capabilities = {
       console.log("target_temperature:get");
       // Retrieve updated data
       getStatus(device.id);
+      var newvalue;
       if (devices[device.id].setTemperature !== 0) {
         newvalue = devices[device.id].setTemperature;
       } else {
@@ -178,15 +181,23 @@ function getStatus(device_id) {
     } else {
         Homey.log('Removed Heatlink '+ device_id +' (old settings)');
         module.exports.setUnavailable({id: device_id}, "No Heatlink found" );
-        clearInterval(refreshIntervalId);
+        // Only clear interval when the unavailable device is the only device on this driver
+        // This will prevent stopping the polling when a user has 1 device with old settings and 1 with new
+        // In the event that a user has multiple devices with old settings this function will get called every 10 seconds but that should not be a problem
+        if(Object.keys(devices).length === 1) {
+            clearInterval(refreshIntervalId);
+        }
     }
  }
  
  function startPolling() {
-    refreshIntervalId = setInterval(function () {
-      Homey.log("--Start Heatlink Polling-- ");
-      Object.keys(devices).forEach(function (device_id) {
-        getStatus(device_id);
-      });
-    }, 1000 * 10);
+	   if (refreshIntervalId) {
+		     clearInterval(refreshIntervalId);
+	   }
+     refreshIntervalId = setInterval(function () {
+         Homey.log("--Start Heatlink Polling-- ");
+         Object.keys(devices).forEach(function (device_id) {
+             getStatus(device_id);
+         });
+     }, 1000 * 10);
  }

--- a/drivers/homewizard/driver.js
+++ b/drivers/homewizard/driver.js
@@ -1,6 +1,7 @@
-var devices = [];
+var devices = {};
 var homewizard = require('./../../includes/homewizard.js');
 var request = require('request');
+var refreshIntervalId;
 
 // SETTINGS
 module.exports.settings = function( device_data, newSettingsObj, oldSettingsObj, changedKeysArr, callback ) {
@@ -39,7 +40,8 @@ module.exports.pair = function( socket ) {
                 homewizard.setDevices(devices);
                 callback( null, devices );
                 socket.emit("success", device);
-			} else {
+                startPolling();
+      } else {
 				//false
                 socket.emit("error", "no response");
 			}
@@ -78,9 +80,13 @@ module.exports.init = function(devices_data, callback) {
 	callback (null, true);
 };
 
-module.exports.deleted = function( device_data ) {  
+module.exports.deleted = function( device_data ) {
+    delete devices[device_data.id];
+    if (Object.keys(devices).length === 0) {
+      clearInterval(refreshIntervalId);
+      Homey.log("--Stopped Polling--");
+    }
     Homey.log('deleted: ' + JSON.stringify(device_data));
-    devices[device_data.id] = [];
 };
 
 // SCENES
@@ -179,10 +185,13 @@ function getStatus(device_id) {
 }
  
 function startPolling() {
-   refreshIntervalId = setInterval(function () {
-     Homey.log("--Start HomeWizard Polling-- ");
-     Object.keys(devices).forEach(function (device_id) {
-       getStatus(device_id);
-     });
-   }, 1000 * 10);
+    if (refreshIntervalId) {
+        clearInterval(refreshIntervalId);
+    }
+    refreshIntervalId = setInterval(function () {
+        Homey.log("--Start HomeWizard Polling-- ");
+        Object.keys(devices).forEach(function (device_id) {
+            getStatus(device_id);
+        });
+    }, 1000 * 10);
 }


### PR DESCRIPTION
Changed `devices` to an object since it is used as a object
Fixed startPolling/stopPolling logic to accommodate for usecases with multiple devices on the same driver
Fixed some instances where variables were implicitly declared (without `var`)